### PR TITLE
add missing required length option for string type 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
   ],
   "require": {
     "php": ">=8.2",
-    "doctrine/dbal": "^2.13.1|^3.2",
-    "doctrine/orm": "^2.13",
+    "doctrine/dbal": "^2.13.1|^3.2|^4",
+    "doctrine/orm": "^2.13|^3",
     "symfony/cache": "^5.4|^6.0|^7.0",
     "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
     "symfony/lock": "^5.4|^6.0|^7.0",

--- a/src/Provider/Doctrine/Auditing/Logger/Middleware/DHConnection.php
+++ b/src/Provider/Doctrine/Auditing/Logger/Middleware/DHConnection.php
@@ -20,7 +20,7 @@ final class DHConnection extends AbstractConnectionMiddleware
         $this->DHDriver = $DHDriver;
     }
 
-    public function commit(): bool
+    public function commit(): void
     {
         $flusherList = $this->DHDriver->getFlusherList();
         foreach ($flusherList as $flusher) {
@@ -29,13 +29,13 @@ final class DHConnection extends AbstractConnectionMiddleware
 
         $this->DHDriver->resetDHFlusherList();
 
-        return parent::commit();
+        parent::commit();
     }
 
-    public function rollBack(): bool
+    public function rollBack(): void
     {
         $this->DHDriver->resetDHFlusherList();
 
-        return parent::rollBack();
+        parent::rollBack();
     }
 }

--- a/src/Provider/Doctrine/Persistence/Event/CreateSchemaListener.php
+++ b/src/Provider/Doctrine/Persistence/Event/CreateSchemaListener.php
@@ -9,7 +9,7 @@ use DH\Auditor\Provider\Doctrine\Persistence\Schema\SchemaManager;
 use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\Auditor\Provider\Doctrine\Service\StorageService;
 use DH\Auditor\Tests\Provider\Doctrine\Persistence\Event\CreateSchemaListenerTest;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
 use Exception;
 
@@ -31,9 +31,9 @@ final class CreateSchemaListener
 
         // check inheritance type and returns if unsupported
         if (!\in_array($metadata->inheritanceType, [
-            ClassMetadataInfo::INHERITANCE_TYPE_NONE,
-            ClassMetadataInfo::INHERITANCE_TYPE_JOINED,
-            ClassMetadataInfo::INHERITANCE_TYPE_SINGLE_TABLE,
+            ClassMetadata::INHERITANCE_TYPE_NONE,
+            ClassMetadata::INHERITANCE_TYPE_JOINED,
+            ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE,
         ], true)) {
             throw new Exception(sprintf('Inheritance type "%s" is not yet supported', $metadata->inheritanceType));
         }
@@ -44,7 +44,7 @@ final class CreateSchemaListener
             $audited = false;
             if (
                 $metadata->rootEntityName === $metadata->name
-                && ClassMetadataInfo::INHERITANCE_TYPE_SINGLE_TABLE === $metadata->inheritanceType
+                && ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE === $metadata->inheritanceType
             ) {
                 foreach ($metadata->subClasses as $subClass) {
                     if ($this->provider->isAuditable($subClass)) {

--- a/src/Provider/Doctrine/Persistence/Helper/SchemaHelper.php
+++ b/src/Provider/Doctrine/Persistence/Helper/SchemaHelper.php
@@ -32,6 +32,7 @@ abstract class SchemaHelper
                 'type' => DoctrineHelper::getDoctrineType('STRING'),
                 'options' => [
                     'notnull' => true,
+                    'length' => 10,
                 ],
             ],
             'discriminator' => [
@@ -39,6 +40,7 @@ abstract class SchemaHelper
                 'options' => [
                     'default' => null,
                     'notnull' => false,
+                    'length' => 255,
                 ],
             ],
             'transaction_hash' => [
@@ -60,6 +62,7 @@ abstract class SchemaHelper
                 'options' => [
                     'default' => null,
                     'notnull' => false,
+                    'length' => 10,
                 ],
             ],
             'blame_user' => [

--- a/src/Provider/Doctrine/Persistence/Reader/Query.php
+++ b/src/Provider/Doctrine/Persistence/Reader/Query.php
@@ -109,7 +109,7 @@ final class Query
 
         try {
             $queryBuilder
-                ->add('select', 'COUNT(id)', false)
+                ->addSelect('COUNT(id)')
                 ->resetOrderBy()
                 ->setMaxResults(null)
                 ->setFirstResult(0)


### PR DESCRIPTION
add missing required length option for string type (fix: Doctrine\DBAL\Platforms\MySQL80Platform requires the length of a VARCHAR column to be specified)